### PR TITLE
resume the socket when use socks-agent

### DIFF
--- a/lib/socks-agent.js
+++ b/lib/socks-agent.js
@@ -97,6 +97,8 @@ SocksAgent.prototype.addRequest = function(req, host, port, localAddress) {
             }
         } else {
             req.onSocket(socket);
+            //have to resume this socket when node 12
+            socket.resume();
         }
     });
 


### PR DESCRIPTION
When I use socks-agent as agent of http request client, the on data event couldn't be emitted where in node.js v12(in node.js v10 that's ok ) . After two days inspect the code source, I found the socket had been paused when socks server response the data, but agent  didn't resume the socket then.