### PR TITLE
Fix completely inexplicable EventEmitter problem on net.socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ socks
 
 socks is a full client implementation of the SOCKS 4, 4a, and 5 protocols in an easy to use node.js module.
 
+### This fork is just for use with wtfnode
+This fork of the 'socks' module makes a small change in lib/socks-client.js to the socket.on('data') handler to allow using this module when also using module "wtfnode" (which inserts itself into socket connections to allow listing connections that are open, i.e. which may be preventing the node process from closing e.g. mocha test runs).
+
 ### Notice
 As of February 26th, 2015, socks is the new home of the socks-client package.
 

--- a/lib/socks-client.js
+++ b/lib/socks-client.js
@@ -137,10 +137,12 @@ var SmartBuffer = require('smart-buffer');
             buff.writeUInt8(SOCKS5_AUTH.NoAuth);
             buff.writeUInt8(SOCKS5_AUTH.UserPass);
 
-            socket.once('data', handshake);
+            // socket.once('data', handshake);
+            socket.on('data', handshake);
             socket.write(buff.toBuffer());
 
             function handshake(data) {
+                socket.removeListener('data', handshake);
                 if (data.length !== 2) {
                     finish(new Error("Negotiation Error"), socket, null, callback);
                 } else if (data[0] !== 0x05) {


### PR DESCRIPTION
This stopped working for us when we upgraded to node 8.8.1 from 6. I have no idea why `socket.once('data', handshake)` doesn't run `handshake`, but `socket.on('data', handshake)` does, so... 🤷‍♂️  ?