### PR TITLE
Support Duplex Streams for existing_socket

### DIFF
--- a/src/client/socksclient.ts
+++ b/src/client/socksclient.ts
@@ -442,7 +442,10 @@ class SocksClient extends EventEmitter implements SocksClient {
       this.state = SocksClientState.Error;
 
       // Destroy Socket
-      if (this._socket instanceof net.Socket && !this._socket.destroyed) {
+      if (
+        !(this._socket instanceof net.Socket) ||
+        (this._socket instanceof net.Socket && !this._socket.destroyed)
+      ) {
         this._socket.destroy();
       }
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -11,7 +11,7 @@ const ERRORS = {
   InvalidSocksCommandForOperation: 'An invalid SOCKS command was provided. Only a subset of commands are supported for this operation.',
   InvalidSocksCommandChain: 'An invalid SOCKS command was provided. Chaining currently only supports the connect command.',
   InvalidSocksClientOptionsDestination: 'An invalid destination host was provided.',
-  InvalidSocksClientOptionsExistingSocket: 'An invalid existing socket was provided. This should be an instance of net.Socket.',
+  InvalidSocksClientOptionsExistingSocket: 'An invalid existing socket was provided. This should be an instance of stream.Duplex.',
   InvalidSocksClientOptionsProxy: 'Invalid SOCKS proxy details were provided.',
   InvalidSocksClientOptionsTimeout: 'An invalid timeout value was provided. Please enter a value above 0 (in ms).',
   InvalidSocksClientOptionsProxiesLength: 'At least two socks proxies must be provided for chaining.',

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,3 +1,4 @@
+import { Duplex } from 'stream';
 import { Socket } from 'net';
 
 const DEFAULT_TIMEOUT = 30000;
@@ -140,7 +141,7 @@ interface SocksClientOptions {
   // The amount of time to wait when establishing a proxy connection (ms).
   timeout?: number;
   // Used internally for proxy chaining.
-  existing_socket?: Socket;
+  existing_socket?: Duplex;
 }
 
 /**

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -6,6 +6,7 @@ import {
 import { SocksClientError } from './util';
 import { ERRORS, SocksCommand, SocksProxy } from './constants';
 import * as net from 'net';
+import * as stream from 'stream';
 
 /**
  * Validates the provided SocksClientOptions
@@ -50,7 +51,7 @@ function validateSocksClientOptions(
   // Check existing_socket (if provided)
   if (
     options.existing_socket &&
-    !(options.existing_socket instanceof net.Socket)
+    !(options.existing_socket instanceof stream.Duplex)
   ) {
     throw new SocksClientError(
       ERRORS.InvalidSocksClientOptionsExistingSocket,

--- a/typings/client/socksclient.d.ts
+++ b/typings/client/socksclient.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="node" />
 import { EventEmitter } from 'events';
-import * as net from 'net';
 import { SocksClientOptions, SocksClientChainOptions, SocksRemoteHost, SocksProxy, SocksClientBoundEvent, SocksClientEstablishedEvent, SocksUDPFrameDetails } from '../common/constants';
 import { SocksClientError } from '../common/util';
+import { Duplex } from 'stream';
 interface SocksClient {
     on(event: 'error', listener: (err: SocksClientError) => void): this;
     on(event: 'bound', listener: (info: SocksClientBoundEvent) => void): this;
@@ -67,7 +67,7 @@ declare class SocksClient extends EventEmitter implements SocksClient {
      * Starts the connection establishment to the proxy and destination.
      * @param existing_socket Connected socket to use instead of creating a new one (internal use).
      */
-    connect(existing_socket?: net.Socket): void;
+    connect(existing_socket?: Duplex): void;
     /**
      * Handles internal Socks timeout callback.
      * Note: If the Socks client is not BoundWaitingForConnection or Established, the connection will be closed.

--- a/typings/common/constants.d.ts
+++ b/typings/common/constants.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="node" />
+import { Duplex } from 'stream';
 import { Socket } from 'net';
 declare const DEFAULT_TIMEOUT = 30000;
 declare type SocksProxyType = 4 | 5;
@@ -111,7 +112,7 @@ interface SocksClientOptions {
     destination: SocksRemoteHost;
     proxy: SocksProxy;
     timeout?: number;
-    existing_socket?: Socket;
+    existing_socket?: Duplex;
 }
 /**
  * SocksClient chain connection options.


### PR DESCRIPTION
Currently existing_socket needs to be an instance of `net.Socket` - this is limiting to developers who want to provide a specific stream connected to a proxy server (eg. pre-connected netcat stream). 

Upon providing such stream, the library can provide SOCKS protocol functionality including authentication.