### PR TITLE
Call unref on timeout

### DIFF
--- a/src/client/socksclient.ts
+++ b/src/client/socksclient.ts
@@ -281,7 +281,7 @@ class SocksClient extends EventEmitter implements SocksClient {
     setTimeout(
       () => this.onEstablishedTimeout(),
       this._options.timeout || DEFAULT_TIMEOUT
-    );
+    ).unref();
 
     // If an existing socket is provided, use it to negotiate SOCKS handshake. Otherwise create a new Socket.
     if (existing_socket) {


### PR DESCRIPTION
Calling unref on timeout will not require the node.js event loop to remain active and permit to the process to exit