### PR TITLE
Add TCP NO_DELAY option

### DIFF
--- a/src/client/socksclient.ts
+++ b/src/client/socksclient.ts
@@ -311,6 +311,9 @@ class SocksClient extends EventEmitter implements SocksClient {
         this._options.proxy.port,
         this._options.proxy.ipaddress
       );
+      if (this._options.set_tcp_nodelay) {
+        (this._socket as net.Socket).setNoDelay(true);
+      }
     }
 
     // Listen for established event so we can re-emit any excess data received during handshakes.

--- a/src/client/socksclient.ts
+++ b/src/client/socksclient.ts
@@ -311,8 +311,8 @@ class SocksClient extends EventEmitter implements SocksClient {
         this._options.proxy.port,
         this._options.proxy.ipaddress
       );
-      if (this._options.set_tcp_nodelay) {
-        (this._socket as net.Socket).setNoDelay(true);
+      if (this._options.set_tcp_nodelay !== undefined && this._options.set_tcp_nodelay !== null) {
+        (this._socket as net.Socket).setNoDelay(!!this._options.set_tcp_nodelay);
       }
     }
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -142,6 +142,8 @@ interface SocksClientOptions {
   timeout?: number;
   // Used internally for proxy chaining.
   existing_socket?: Duplex;
+  // Whether to set TCP_NODELAY
+  set_tcp_nodelay?: boolean;
 }
 
 /**

--- a/typings/common/constants.d.ts
+++ b/typings/common/constants.d.ts
@@ -113,6 +113,7 @@ interface SocksClientOptions {
     proxy: SocksProxy;
     timeout?: number;
     existing_socket?: Duplex;
+    set_tcp_nodelay?: boolean;
 }
 /**
  * SocksClient chain connection options.


### PR DESCRIPTION
Although [nodejs documentation](https://nodejs.org/api/net.html#net_socket_setnodelay_nodelay) states the TCP NO_DELAY is by default true. This does not seem to be right, at least not with all platform (mine is MacOS).

Since I am using this library for terminal sessions I have noticed terminals being choppy when established through this library. Adding option to manually set TCP_NODELAY to true resolves this issue.

This may help others when struggling with the same issue.

Configuration option `set_tcp_nodelay` has been added and setting it to true will call setNoDelay(true) on newly created socket while connecting.