### PR TITLE
Export SocksClientError so it can be used in clients

### DIFF
--- a/typings/client/socksclient.d.ts
+++ b/typings/client/socksclient.d.ts
@@ -156,4 +156,4 @@ declare class SocksClient extends EventEmitter implements SocksClient {
     private handleSocks5IncomingConnectionResponse;
     get socksClientOptions(): SocksClientOptions;
 }
-export { SocksClient, SocksClientOptions, SocksClientChainOptions, SocksRemoteHost, SocksProxy, SocksUDPFrameDetails };
+export { SocksClient, SocksClientOptions, SocksClientChainOptions, SocksClientError, SocksRemoteHost, SocksProxy, SocksUDPFrameDetails };


### PR DESCRIPTION
Simply export SocksClientError so 
`import { SocksClientError } from 'socks/typings/common/util';
`
can become
`import { SocksClientError } from 'socks';
`
which creates less dependencies on the package itself. Let me know what you think!