### PR TITLE
Optimize npm package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,10 @@
     "tslint": "^5.8.0",
     "typescript": "3.7.2"
   },
+  "files": [
+    "lib",
+    "index.js"
+  ],
   "dependencies": {
     "ip": "1.1.5",
     "smart-buffer": "^4.1.0"


### PR DESCRIPTION
It doesn't make sense to deliver not needed for user files