### PR TITLE
added remoteHost to info callback variable upon successful socks5 connection

### DIFF
--- a/src/client/socksclient.ts
+++ b/src/client/socksclient.ts
@@ -843,7 +843,7 @@ class SocksClient extends EventEmitter implements SocksClient {
       if (SocksCommand[this.options.command] === SocksCommand.connect) {
         this.setState(SocksClientState.Established);
         this.removeInternalSocketHandlers();
-        this.emit('established', {socket: this.socket});
+        this.emit('established', {remoteHost, socket: this.socket});
       } else if (SocksCommand[this.options.command] === SocksCommand.bind) {
         /* If using BIND, the Socks client is now in BoundWaitingForConnection state.
            This means that the remote proxy server is waiting for a remote connection to the bound port. */


### PR DESCRIPTION
Function `handleSocks5FinalHandshakeResponse()` parses but does not pass the `remoteHost` object back to the caller only when the client uses using the `connect` method. It does with the other two `bind` and `associate` methods.