### PR TITLE
docs: add node-socks-proxy-agent note

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Fully featured SOCKS proxy client supporting SOCKSv4, SOCKSv4a, and SOCKSv5. Includes Bind and Associate functionality.
 
+> Looking for Node.js agent? Check [node-socks-proxy-agent](https://github.com/TooTallNate/node-socks-proxy-agent).
+
 ### Features
 
 * Supports SOCKS v4, v4a, v5, and v5h protocols.


### PR DESCRIPTION
Hello,

I added a note over the README for users looking at this repo to use a high level wrapper to use for HTTP/HTTPS requests, since `node-socks-proxy-agent` is essentially wrapping `socks` to accommodate it correctly.

I also take this opportunity to tell, in case you want, you're fully invited to be part of `node-socks-proxy-agent` core maintainers 🙂