### PR TITLE
Bug fix createConnectionChain - creating a tunnel

### DIFF
--- a/src/client/socksclient.ts
+++ b/src/client/socksclient.ts
@@ -167,14 +167,14 @@ class SocksClient extends EventEmitter implements SocksClient {
         }
       }
 
-      let sock: net.Socket;
-
       // Shuffle proxies
       if (options.randomizeChain) {
         shuffleArray(options.proxies);
       }
 
       try {
+        let sock: net.Socket;
+
         for (let i = 0; i < options.proxies.length; i++) {
           const nextProxy = options.proxies[i];
 
@@ -194,13 +194,11 @@ class SocksClient extends EventEmitter implements SocksClient {
             command: 'connect',
             proxy: nextProxy,
             destination: nextDestination,
-            // Initial connection ignores this as sock is undefined. Subsequent connections re-use the first proxy socket to form a chain.
+            existing_socket: sock,
           });
 
           // If sock is undefined, assign it here.
-          if (!sock) {
-            sock = result.socket;
-          }
+          sock = sock || result.socket;
         }
 
         if (typeof callback === 'function') {


### PR DESCRIPTION
The current implementation returns a socket to the first proxy in the chain - this is the bug (reproduce: the example in the README does not work). The method "createConnectionChain" should return a socket to the final destination which is tunnelled through the given proxies. Therefore each iteration over the array of proxies must carry forward the socket. This PR is implementing this and hence fixing the bug.