### PR TITLE
avoid return promise when callback is specified

### DIFF
--- a/test/socksclient.test.ts
+++ b/test/socksclient.test.ts
@@ -435,7 +435,7 @@ describe('Validating SocksProxyOptions', () => {
 describe('SocksClient', () => {
   describe('createConnection', () => {
     it('should call the callback with an error when options validation fails and callback is provided', () => {
-      SocksClient.createConnection(
+      const returnValue = SocksClient.createConnection(
         {
           destination: {
             host: '1.2.3.4',
@@ -452,6 +452,7 @@ describe('SocksClient', () => {
           assert(err instanceof SocksClientError);
         },
       );
+      assert(returnValue === undefined);
     });
 
     it('should reject promise when options validation fails and callback is not provided', async () => {
@@ -480,7 +481,7 @@ describe('SocksClient', () => {
 
   describe('createConnectionChain', () => {
     it('should call the callback with an error when options validation fails and callback is provided', () => {
-      SocksClient.createConnectionChain(
+      const returnValue = SocksClient.createConnectionChain(
         {
           destination: {
             host: '1.2.3.4',
@@ -504,6 +505,7 @@ describe('SocksClient', () => {
           assert(err instanceof SocksClientError);
         },
       );
+      assert(returnValue === undefined);
     });
 
     it('should reject promise when options validation fails and callback is not provided', async () => {

--- a/typings/client/socksclient.d.ts
+++ b/typings/client/socksclient.d.ts
@@ -18,6 +18,7 @@ declare interface SocksClient {
     emit(event: 'bound', info: SocksClientBoundEvent): boolean;
     emit(event: 'established', info: SocksClientEstablishedEvent): boolean;
 }
+export declare type EstablishCallback = (error: Error | null, info?: SocksClientEstablishedEvent) => void;
 declare class SocksClient extends EventEmitter implements SocksClient {
     private options;
     private socket;
@@ -38,7 +39,8 @@ declare class SocksClient extends EventEmitter implements SocksClient {
      * @param callback { Function } An optional callback function.
      * @returns { Promise }
      */
-    static createConnection(options: SocksClientOptions, callback?: (error: Error | null, info?: SocksClientEstablishedEvent) => void): Promise<SocksClientEstablishedEvent>;
+    static createConnection(options: SocksClientOptions, callback: EstablishCallback): void;
+    static createConnection(options: SocksClientOptions): Promise<SocksClientEstablishedEvent>;
     /**
      * Creates a new SOCKS connection chain to a destination host through 2 or more SOCKS proxies.
      *
@@ -48,7 +50,8 @@ declare class SocksClient extends EventEmitter implements SocksClient {
      * @param callback { Function } An optional callback function.
      * @returns { Promise }
      */
-    static createConnectionChain(options: SocksClientChainOptions, callback?: (error: Error | null, socket?: SocksClientEstablishedEvent) => void): Promise<SocksClientEstablishedEvent>;
+    static createConnectionChain(options: SocksClientChainOptions, callback: EstablishCallback): void;
+    static createConnectionChain(options: SocksClientChainOptions): Promise<SocksClientEstablishedEvent>;
     /**
      * Creates a SOCKS UDP Frame.
      * @param options


### PR DESCRIPTION
Refactor `SocksClient.createConnection` & `SocksClient.createConnectionChain` that return a promise only if the `callback` argument is undefined.

Removes `resolve(err as any); // Resolves pending promise (prevents memory leaks).` hack