### PR TITLE
ipv4ToInt32 should return unsigned integer

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -214,7 +214,7 @@ export {validateSocksClientOptions, validateSocksClientChainOptions};
 export function ipv4ToInt32(ip: string): number {
   const address = new Address4(ip);
   // Convert the IPv4 address parts to an integer
-  return address.toArray().reduce((acc, part) => (acc << 8) + part, 0);
+  return address.toArray().reduce((acc, part) => (acc << 8) + part, 0) >>> 0;
 }
 
 export function int32ToIpv4(int32: number): string {


### PR DESCRIPTION
At least ‎SocksClient.createUDPFrame expects that: `buff.writeUInt32BE(ipv4ToInt32(options.remoteHost.host))`.

`>>> 0` is fast and easy way to make integer unsigned:
`[200,200,200,200].reduce((acc, part) => (acc << 8) + part, 0)` 
`-926365496`
`[200,200,200,200].reduce((acc, part) => (acc << 8) + part, 0) >>> 0` 
`3368601800`
