### PR TITLE
Corrected the UDP Relay section in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ udpSocket.on('message', (message, rinfo) => {
   */
 });
 
-let client = new SocksClient(associateOptions);
+let client = new SocksClient(options);
 
 // When the UDP relay is established, this event is fired and includes the UDP relay port to send data to on the proxy server.
 client.on('established', info => {
@@ -361,7 +361,7 @@ client.on('established', info => {
   // Send 'hello' to 165.227.108.231:4444
   const packet = SocksClient.createUDPFrame({
     remoteHost: { host: '165.227.108.231', port: 4444 },
-    data: Buffer.from(line)
+    data: Buffer.from('hello')
   });
   udpSocket.send(packet, info.remoteHost.port, info.remoteHost.host);
 });


### PR DESCRIPTION
I attempted to use the library to send UDP packets through SOCKS5, following the instructions in the README's UDP Relay section.
However, it did not work as expected. The issue was in the example provided in the README.

This Pull Request provides fixes to the UDP Relay section of the README to ensure that the example works correctly.