### PR TITLE
fix: prevent RangeError by validating domain length in socks5 client

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -180,6 +180,7 @@ function isValidSocksRemoteHost(remoteHost: SocksRemoteHost) {
   return (
     remoteHost &&
     typeof remoteHost.host === 'string' &&
+    Buffer.byteLength(remoteHost.host) < 256 &&
     typeof remoteHost.port === 'number' &&
     remoteHost.port >= 0 &&
     remoteHost.port <= 65535

--- a/test/socksclient.test.ts
+++ b/test/socksclient.test.ts
@@ -98,6 +98,11 @@ describe('Validating SocksProxyOptions', () => {
     port: undefined,
   } as any;
 
+  const socksRemoteHostMaxLengthDomain: SocksRemoteHost = {
+    host: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com',
+    port: 80,
+  } as any;
+
   const socksCommandValid = 'connect';
   const socksCommandInvalid: any = 'other';
 
@@ -295,6 +300,16 @@ describe('Validating SocksProxyOptions', () => {
         proxy: socksProxyValid,
         command: socksCommandValid,
         destination: socksRemoteHostInvalidHost,
+      });
+    }, SocksClientError);
+  });
+
+   it('should throw an exception when domain length exceeds 255 bytes', () => {
+    assert.throws(() => {
+      validateSocksClientOptions({
+        proxy: socksProxyValid,
+        command: socksCommandValid,
+        destination: socksRemoteHostMaxLengthDomain,
       });
     }, SocksClientError);
   });


### PR DESCRIPTION
This PR fixes an issue where SOCKS5 clients could attempt to send domain names longer than 255 bytes, causing a `RangeError` during buffer writes.

According to [RFC 1928](https://datatracker.ietf.org/doc/html/rfc1928#section-5) (SOCKS5), when sending a domain name (ATYP = 0x03),  
the first byte indicates the length of the domain in bytes, meaning the  
maximum allowed domain name length is 255 bytes.

Previously, domain names longer than 255 bytes caused a `RangeError` when  
writing the length byte to the buffer. This fix adds an explicit check  
and throws a descriptive error if the domain is too long.

## Changes

- Added domain length validation before encoding SOCKS5 requests
- Throws clear error if domain length exceeds 255 bytes
- Uses `Buffer.byteLength()` for accurate UTF-8 byte count

## Testing

- Added unit tests verifying exception is thrown for domains > 255 bytes
- Verified existing tests continue to pass
