### PR TITLE
Upgrade ip-address to address CVE (socks is not affected)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "socks",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "socks",
-      "version": "2.8.6",
+      "version": "2.8.7",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "devDependencies": {
@@ -1339,9 +1339,9 @@
       "dev": true
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "ip-address": "^10.0.1",
+    "ip-address": "^10.1.1",
     "smart-buffer": "^4.2.0"
   },
   "scripts": {


### PR DESCRIPTION
I'm the maintainer of `ip-address`. We had a CVE reported, so downstream users of `socks` will likely see it. `socks` itself is not affected (honestly, I don't think anyone is) but to address the CVE here's a PR to upgrade `ip-address` to the version that addresses the CVE. There are no functionality changes and the tests pass.

Note: `npm install` caused the `package-lock.json` to pick up the latest `socks` version number. That seemed fine.
